### PR TITLE
Addresses [Bug]: Layout Issue – Text Clipped or Misaligned on Home page. #75

### DIFF
--- a/src/Home.css
+++ b/src/Home.css
@@ -227,6 +227,10 @@ body {
   flex: 1 1 0%;
 }
 
+.flex-shrink-0 {
+  flex-shrink:0;
+}
+
 .flex-col {
   flex-direction: column;
 }

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -759,8 +759,27 @@ const questions = [
                   </div>
                 </div>
               </div>
-              <div className="flex items-center justify-center lg:justify-end animate-on-scroll">
-                <div className="relative w-full max-w-[400px]">
+              <div className="flex items-center justify-center lg:justify-end gap-4 animate-on-scroll">
+                <div className="flex-shrink-0 h-24 w-24 rounded-lg border bg-background p-2 shadow-lg transition-all duration-300 hover:scale-110">
+                  <div className="flex h-full w-full items-center justify-center rounded bg-emerald-100">
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="24"
+                      height="24"
+                      viewBox="0 0 24 24"
+                      fill="none"
+                      stroke="currentColor"
+                      strokeWidth="2"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      className="h-10 w-10 text-emerald-500"
+                    >
+                      <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
+                      <circle cx="12" cy="10" r="3" />
+                    </svg>
+                  </div>
+                </div>
+                <div className="flex items-center w-full max-w-[400px]">
                   <div className="overflow-hidden rounded-lg border shadow-xl transition-all duration-500 hover:shadow-2xl hover:scale-[1.02]">
                     <img
                       src="public/civix-mobile.png"
@@ -769,25 +788,7 @@ const questions = [
                       loading="lazy"
                     />
                   </div>
-                  <div className="absolute -bottom-6 -left-6 h-24 w-24 rounded-lg border bg-background p-2 shadow-lg transition-all duration-300 hover:scale-110">
-                    <div className="flex h-full w-full items-center justify-center rounded bg-emerald-100">
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        width="24"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        fill="none"
-                        stroke="currentColor"
-                        strokeWidth="2"
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        className="h-10 w-10 text-emerald-500"
-                      >
-                        <path d="M20 10c0 6-8 12-8 12s-8-6-8-12a8 8 0 0 1 16 0Z" />
-                        <circle cx="12" cy="10" r="3" />
-                      </svg>
-                    </div>
-                  </div>
+                  
                 </div>
               </div>
             </div>


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description

Addresses [Bug]: Layout Issue – Text Clipped or Misaligned on Home page.

Home.css Line 230 - 233: Added a flex-shrink-0 class to prevent element distortion.
Home.jsx Line 762 - 791: Reposition icon div to creating stacking context for flexbox AND to just make the overall intuitive more overall.
Home.jsx  Line 762:
 - Added flex to display flex
 - Added gap-4 to create appropriate spacing between elements
 - Took away absolute -bottom-6 -left-6 h-24 w-24 
Home.jsx  Line 762: Added flex-shrink-0 to prevent element distortion


Fixes: #75 

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [] I have updated relevant documentation
- [x] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Note: since "public/civix-mobile.png" is not found, the alt text has been used as seen in the original. It has not been visually centered as I don't know the size of the final image looks like. However, the overall child divs in the parent flex container has been centered. 
 
Screenshots with Pesticide Visuals:

Mobile Screen
<img width="460" alt="Screenshot 2025-06-16 at 8 51 42 am" src="https://github.com/user-attachments/assets/8d398575-17b2-4612-90b2-fecc826657c9" />

Tablet Screen
<img width="1011" alt="Screenshot 2025-06-16 at 8 52 09 am" src="https://github.com/user-attachments/assets/780b850b-ce5d-4497-a799-88f6e5d4089e" />

Desktop Screen
<img width="1213" alt="Screenshot 2025-06-16 at 8 52 34 am" src="https://github.com/user-attachments/assets/7c7f3c71-9964-4c89-a8d3-df886f38e411" />

Include screenshots or screen recordings of your change.
