### PR TITLE
Add chevron icon to FAQ section in DownloadAndroid.jsx

### DIFF
--- a/src/Pages/DownloadAndroid.jsx
+++ b/src/Pages/DownloadAndroid.jsx
@@ -81,7 +81,18 @@ const DownloadAndroid = () => {
             className={`faq-item ${openFAQ === index ? 'open' : ''}`}
             onClick={() => toggleFAQ(index)}
           >
-            <div className="faq-question">{faq.question}</div>
+            <div className="faq-question" style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
+              <span>{faq.question}</span>
+              {openFAQ === index ? (
+                <svg className="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M5 15l7-7 7 7"></path>
+                </svg>
+              ) : (
+                <svg className="w-5 h-5 text-emerald-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M19 9l-7 7-7-7"></path>
+                </svg>
+              )}
+            </div>
             {openFAQ === index && <div className="faq-answer">{faq.answer}</div>}
           </div>
         ))}


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description

Added a chevron (down arrow) icon next to each FAQ question in the `DownloadAndroid.jsx` page to enhance visual clarity and user experience.

Fixes: *N/A*

## 📂 Type of Change

* [ ] Bug Fix 🐛
* [x] UI/UX Enhancement 🎨
* [ ] New Feature ✨
* [ ] Documentation 📚
* [ ] Refactor 🧹
* [ ] Other:

## 📋 Checklist

* [x] My code follows the contribution guidelines of Civix
* [x] I have tested my changes locally
* [ ] I have updated relevant documentation
* [ ] I have linked related issues (if any)
* [x] This pull request is ready to be reviewed

# Before it was

![img01](https://github.com/user-attachments/assets/6eb33916-4637-42d4-8cce-8d1195e67bb4)

# After it is

<img width="1366" height="768" alt="Screenshot (88)" src="https://github.com/user-attachments/assets/10312774-72dd-4b42-9b60-bdf7a7763ab9" />
