### PR TITLE
fix: scroll position now resets on route change

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,6 +32,7 @@ import MyComplaints from './Pages/MyComplaints';
 import CivicEducation from './Pages/CivicEducation';
 import CivicSimulator from './Pages/CivicSimulator';
 import Contributors from './Pages/Contributors';
+import ScrollToTopOnRouteChange from './components/ScrollToTopOnRouteChange';
 
 const App = () => {
   const { isSignedIn } = useAuth();
@@ -39,6 +40,7 @@ const App = () => {
   return (
     <>
       <ScrollToTop />
+      <ScrollToTopOnRouteChange/>
       <Toaster
         position="top-right"
         toastOptions={{

--- a/src/components/ScrollToTopOnRouteChange.jsx
+++ b/src/components/ScrollToTopOnRouteChange.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+const ScrollToTopOnRouteChange = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'smooth' });
+  }, [pathname]); // Triggers on route change
+
+  return null;
+};
+
+export default ScrollToTopOnRouteChange;


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description

Added automatic scroll-to-top behavior on route change using a `ScrollToTopOnRouteChange` component and also retained the existing `ScrollToTop` button for manual scroll functionality.

Fixes: #321 

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [x] I have linked related issues 
- [x] This pull request is ready to be reviewed
