### PR TITLE
Add centered 'Back to Top' button to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,3 +330,8 @@ Pull requests are welcome! For major changes, please open an issue first to disc
 ## 📄 License
 MIT License. See LICENSE file for more details.
 
+<p align="center">
+  <a href="#top" style="font-size: 18px; padding: 8px 16px; display: inline-block; border: 1px solid #ccc; border-radius: 6px; text-decoration: none;">
+    ⬆️ Back to Top
+  </a>
+</p>


### PR DESCRIPTION
This pull request adds a small, centered "🔝 Back to Top" button at the end of the README file to improve user navigation.
As the README is quite long, this enhancement allows users to quickly scroll back to the top, enhancing overall readability and experience.

✅ Checklist
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have commented my code where necessary
 I have made corresponding changes to the documentation
 My changes generate no new warnings or errors
 I have linked the related issue using Fixes #304 