### PR TITLE
fix: dark mode on login page and about page text

### DIFF
--- a/src/Pages/About.css
+++ b/src/Pages/About.css
@@ -35,7 +35,7 @@
 
 @media (prefers-color-scheme: dark) {
   .heading2 {
-    color: #e2e8f0;
+    color: hsl(213, 14%, 73%);
   }
 }
 

--- a/src/components/Login.jsx
+++ b/src/components/Login.jsx
@@ -55,14 +55,14 @@ const Login = () => {
     };
 
     return (
-        <div className="relative flex min-h-screen items-center justify-center overflow-hidden bg-gradient-to-br from-gray-50 via-blue-50 to-green-50 font-inter">
-            <MinimalBG />
+        <div className="relative flex min-h-screen items-center justify-center overflow-hidden font-inter dark:bg-gray-900">
+            {/* <MinimalBG /> */}
             
             {/* Decorative background elements */}
-            <div className="absolute inset-0 overflow-hidden">
+            {/* <div className="absolute inset-0 overflow-hidden">
                 <div className="absolute -top-40 -right-40 h-80 w-80 rounded-full bg-green-100 opacity-20 blur-3xl"></div>
                 <div className="absolute -bottom-40 -left-40 h-80 w-80 rounded-full bg-blue-100 opacity-20 blur-3xl"></div>
-            </div>
+            </div> */}
 
             {/* Login Form Container */}
             <div className="relative z-10 w-full max-w-md transform transition-all duration-300 hover:scale-[1.02]">


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description



This pull request addresses an inconsistency in the dark mode implementation on the Login page. Previously, toggling dark mode only updated the navbar background, while the rest of the page remained unchanged. This issue has been resolved by updating the relevant Tailwind CSS classes within the Login.jsx component to ensure a consistent dark mode experience across the entire page.

Additionally, some 3D image rendering code on the Login page has been commented out. The image was misaligned and visually out of place, detracting from the overall UI consistency.

Fixes: #365 









## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [x] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [ ] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)


Earlier it looked like this

<img width="1902" height="1021" alt="Screenshot from 2025-07-28 18-15-47" src="https://github.com/user-attachments/assets/29a8800a-882a-4879-8305-18d0533c4b52" />



After fixing the issue

<img width="1902" height="1021" alt="Screenshot from 2025-07-29 00-37-28" src="https://github.com/user-attachments/assets/42af3996-7937-4173-89ed-468b41f1795b" />

## Additional changes



Along with this, made some additional changes on the about page. The text heading in light mode were not clearly visible on the About page.

<img width="1902" height="1021" alt="Screenshot from 2025-07-28 23-27-02" src="https://github.com/user-attachments/assets/c412e187-8558-4658-996b-4dd66b6f67bf" />



Fixed it by changing the css property

<img width="1902" height="1021" alt="Screenshot from 2025-07-28 23-27-10" src="https://github.com/user-attachments/assets/81c1ccb3-1ac3-4db8-911a-2876316adfb9" />


Include screenshots or screen recordings of your change.
