### PR TITLE
enhance JWT middleware to support token from cookies, body, and headers

### DIFF
--- a/backend/middlewares/validate.js
+++ b/backend/middlewares/validate.js
@@ -3,20 +3,23 @@ const jwt = require('jsonwebtoken');
 
 // Basic token validation
 const verifyToken = (req, res, next) => {
-  const authHeader = req.headers.authorization;
+  let token =
+    req.cookies?.token ||
+    req.body?.token ||
+    req.headers.authorization?.startsWith('Bearer ')
+      ? req.headers.authorization.split(' ')[1]
+      : null;
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+  if (!token) {
     return res.status(401).json({ message: 'No token provided' });
   }
-
-  const token = authHeader.split(' ')[1];
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);
     req.user = decoded;
     next();
   } catch (err) {
-    return res.status(403).json({ message: 'Invalid token' });
+    return res.status(403).json({ message: 'Invalid or expired token' });
   }
 };
 


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description
This PR improves the verifyToken middleware by adding support for extracting JWT tokens from multiple sources. Previously, the middleware only checked the Authorization header for a Bearer token. This was problematic when clients sent tokens via cookies or in the request body.

Please describe what this PR does and link any related issues.

Fixes: #368

## 📂 Type of Change

- [ ] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [ ] My code follows the contribution guidelines of Civix
- [ ] I have tested my changes locally
- [ ] I have updated relevant documentation
- [ ] I have linked related issues (if any)
- [ ] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Include screenshots or screen recordings of your change.
