### PR TITLE
Fix letter clip in heading of privacy page

### DIFF
--- a/src/Pages/Privacy.jsx
+++ b/src/Pages/Privacy.jsx
@@ -48,7 +48,7 @@ function Privacy() {
             <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-emerald-500 to-emerald-600 rounded-2xl mb-8 shadow-lg transform rotate-3 hover:rotate-0 transition-transform duration-300">
               <Shield className="w-10 h-10 text-white" />
             </div>
-            <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-emerald-600 via-blue-600 to-indigo-600 bg-clip-text text-transparent mb-6">
+            <h1 className="text-5xl md:text-6xl font-bold bg-gradient-to-r from-emerald-600 via-blue-600 to-indigo-600 bg-clip-text text-transparent mb-6 py-2">
               Privacy Policy
             </h1>
             <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description

I have fixed the clipping of letter y in heading of privacy page by adding vertical padding

Fixes: #436 

## 📂 Type of Change

- [✅  ] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [✅  ] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [ ✅ ] My code follows the contribution guidelines of Civix
- [✅  ] I have tested my changes locally
- [ ✅ ] I have updated relevant documentation
- [✅  ] I have linked related issues (if any)
- [✅  ] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

<img width="1886" height="607" alt="Screenshot 2025-08-04 173937" src="https://github.com/user-attachments/assets/95996e6d-7ba0-46d6-b43b-71f634ffe644" />

