### PR TITLE
FIX #654: Fix cutoff character in voting page

### DIFF
--- a/src/Pages/VotingSystem.jsx
+++ b/src/Pages/VotingSystem.jsx
@@ -69,7 +69,7 @@ const VotingSystem = () => {
           <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-r from-green-400 to-emerald-500 dark:from-green-500 dark:to-emerald-600 rounded-2xl mb-6 shadow-lg">
             <Vote className="w-10 h-10 text-white" />
           </div>
-          <h1 className="text-5xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 dark:from-green-400 dark:to-emerald-400 bg-clip-text text-transparent mb-4">
+          <h1 className="text-5xl font-bold bg-gradient-to-r from-green-600 to-emerald-600 dark:from-green-400 dark:to-emerald-400 bg-clip-text text-transparent mb-4 pb-3">
             Voting System
           </h1>
           <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description

On the Voting System page, the bottom part of the letter "g" in the heading "Voting System" is cut off. This makes the heading text look clipped and unpolished. So i add bottom padding only to show properly and enhance UI 

Fixes: #654 

## 📂 Type of Change

- [  ✅] Bug Fix 🐛
- [ ] New Feature ✨
- [ ✅ ] Documentation 📚
- [  ✅] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [  ✅ My code follows the contribution guidelines of Civix
- [  ✅] I have tested my changes locally
- [  ✅] I have updated relevant documentation
- [ ✅ ] I have linked related issues (if any)
- [ ✅ ] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

<img width="1850" height="500" alt="Screenshot 2025-08-21 231821" src="https://github.com/user-attachments/assets/d856819e-7c01-4a96-9219-05958aab3edc" />

after changing :>

<img width="1919" height="586" alt="Screenshot 2025-08-22 161555" src="https://github.com/user-attachments/assets/246ea5ac-b429-4920-9de8-87c6db0de813" />


