### PR TITLE
FIX #748: fix cutoff heading in privacy page

### DIFF
--- a/src/Pages/Privacy.jsx
+++ b/src/Pages/Privacy.jsx
@@ -56,7 +56,7 @@ function Privacy() {
           <div className="inline-flex items-center justify-center w-20 h-20 bg-gradient-to-br from-purple-500 to-indigo-600 rounded-2xl mb-8 shadow-xl transform hover:scale-110 hover:rotate-6 transition-all duration-500">
             <Shield className="w-10 h-10 text-white" />
           </div>
-          <h1 className="text-5xl md:text-6xl font-extrabold bg-gradient-to-r from-indigo-600 via-purple-600 to-cyan-500 bg-clip-text text-transparent mb-6">
+          <h1 className="text-5xl md:text-6xl font-extrabold bg-gradient-to-r from-indigo-600 via-purple-600 to-cyan-500 bg-clip-text text-transparent mb-6 pb-3">
             Privacy Policy
           </h1>
           <p className="text-xl text-gray-600 dark:text-gray-300 max-w-3xl mx-auto leading-relaxed">


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description
I have added bottom padding to remove cutoff heading privacy page 

Fixes: #748 

## 📂 Type of Change

- [ ✅] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [ ✅] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [✅ ] My code follows the contribution guidelines of Civix
- [✅ ] I have tested my changes locally
- [ ✅] I have updated relevant documentation
- [ ✅] I have linked related issues (if any)
- [ ✅] This pull request is ready to be reviewed

## 🎥 Screenshots or Demo (if applicable)

Include screenshots or screen recordings of your change.
<img width="1753" height="558" alt="image" src="https://github.com/user-attachments/assets/a5cdc576-b7f9-4404-9827-71315f6fc0b7" />
