### PR TITLE
fix(ui): improve card headline contrast on hover in dark mode

### DIFF
--- a/src/Pages/About.jsx
+++ b/src/Pages/About.jsx
@@ -203,8 +203,8 @@ function About() {
                         <div className="relative mb-5 w-14 h-14 rounded-xl flex items-center justify-center bg-green-50 text-green-600">
                           {feature.icon}
                         </div>
-                        <h3 className="text-lg font-semibold mb-3">{feature.title}</h3>
-                        <p className="text-sm mb-3">{feature.description}</p>
+                        <h3 className="text-lg font-semibold mb-3 text-gray-800 dark:text-gray-100 group-hover:dark:text-gray-800">{feature.title}</h3>
+                        <p className="text-sm mb-3 text-gray-600 dark:text-gray-200 group-hover:dark:text-gray-600">{feature.description}</p>
                         {activeFeature === index && (
                           <p className="text-xs text-slate-500">{feature.details}</p>
                         )}


### PR DESCRIPTION
# 📦 Pull Request: Civix Contribution

## ✅ Description
This PR resolves the UI bug where card headlines and descriptions on the About page became unreadable on hover in dark mode.
By adding specific dark mode and group-hover text color utilities from Tailwind CSS, the text now correctly inverts its color to maintain high contrast against the light background that appears on hover.
Fixes: #671

## 📂 Type of Change

- [x] Bug Fix 🐛
- [ ] New Feature ✨
- [ ] Documentation 📚
- [x] UI/UX Enhancement 🎨
- [ ] Refactor 🧹
- [ ] Other:

## 📋 Checklist

- [x] My code follows the contribution guidelines of Civix
- [x] I have tested my changes locally
- [ ] I have updated relevant documentation
- [x] I have linked related issues (if any)
- [x] This pull request is ready to be reviewed

## 🎥 Screenshots (on hovering)

### Before:
<img width="600" height="600" alt="Screenshot 2025-09-25 200451" src="https://github.com/user-attachments/assets/5acdc45a-2572-4709-98df-ffaa31886f62" />

### After:
<img width="600" height="600" alt="Screenshot 2025-09-28 000120" src="https://github.com/user-attachments/assets/b0387759-4931-4b48-950d-e73c6eeeb288" />
